### PR TITLE
Prototypes can opt out of listing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Prototope"]
 	path = Prototope
 	url = git@github.com:Khan/Prototope.git
+[submodule "ThirdParty/MMMarkdown"]
+	path = ThirdParty/MMMarkdown
+	url = https://github.com/mdiep/MMMarkdown

--- a/Early Math Prototype Player.xcodeproj/project.pbxproj
+++ b/Early Math Prototype Player.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		96DBF3841B3AF25A003E0D46 /* PrototopeJSBridge.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 96DBF3741B3AF243003E0D46 /* PrototopeJSBridge.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		96DBF3901B3AFE68003E0D46 /* protoscope-bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 96DBF38F1B3AFE68003E0D46 /* protoscope-bundle.js */; };
 		EB3CBCF61B3B2ADE0038AE64 /* ReadmeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3CBCF51B3B2ADE0038AE64 /* ReadmeViewController.swift */; };
+		EB7841D21B3BB121008E5160 /* libMMMarkdown-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB7841C61B3BB114008E5160 /* libMMMarkdown-iOS.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,6 +101,34 @@
 			remoteGlobalIDString = EB453D8E1A7AB0B2006F2A72;
 			remoteInfo = PrototopeJSBridge;
 		};
+		EB7841C31B3BB114008E5160 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EB7841BC1B3BB114008E5160 /* MMMarkdown.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BE813DD614F893EB00EC9469;
+			remoteInfo = "MMMarkdown-Mac";
+		};
+		EB7841C51B3BB114008E5160 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EB7841BC1B3BB114008E5160 /* MMMarkdown.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BE813E0E14F8961D00EC9469;
+			remoteInfo = "MMMarkdown-iOS";
+		};
+		EB7841C71B3BB114008E5160 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EB7841BC1B3BB114008E5160 /* MMMarkdown.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BE813DEA14F893EB00EC9469;
+			remoteInfo = MMMarkdownTests;
+		};
+		EB7841C91B3BB114008E5160 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EB7841BC1B3BB114008E5160 /* MMMarkdown.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BE813E1314F92B6100EC9469;
+			remoteInfo = mmmarkdown;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -130,6 +159,8 @@
 		96DBF35D1B3AF243003E0D46 /* Prototope.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Prototope.xcodeproj; path = Prototope/Prototope.xcodeproj; sourceTree = SOURCE_ROOT; };
 		96DBF38F1B3AFE68003E0D46 /* protoscope-bundle.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "protoscope-bundle.js"; sourceTree = "<group>"; };
 		EB3CBCF51B3B2ADE0038AE64 /* ReadmeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadmeViewController.swift; sourceTree = "<group>"; };
+		EB7841BC1B3BB114008E5160 /* MMMarkdown.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MMMarkdown.xcodeproj; path = ThirdParty/MMMarkdown/MMMarkdown.xcodeproj; sourceTree = SOURCE_ROOT; };
+		EB7841D31B3BB13D008E5160 /* Early Math Prototype Player-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Early Math Prototype Player-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +168,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EB7841D21B3BB121008E5160 /* libMMMarkdown-iOS.a in Frameworks */,
 				96DBF37F1B3AF25A003E0D46 /* Prototope.framework in Frameworks */,
 				96DBF3831B3AF25A003E0D46 /* PrototopeJSBridge.framework in Frameworks */,
 			);
@@ -179,6 +211,8 @@
 		962558F91B39AF1A005E4360 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				EB7841D31B3BB13D008E5160 /* Early Math Prototype Player-Bridging-Header.h */,
+				EB7841BC1B3BB114008E5160 /* MMMarkdown.xcodeproj */,
 				96DBF35D1B3AF243003E0D46 /* Prototope.xcodeproj */,
 				962559221B39AFB9005E4360 /* Early-Math-Prototypes */,
 				962558FA1B39AF1A005E4360 /* Info.plist */,
@@ -207,6 +241,17 @@
 				96DBF37A1B3AF243003E0D46 /* ProtocasterTests.xctest */,
 				96DBF37C1B3AF243003E0D46 /* Protoscope.app */,
 				96DBF37E1B3AF243003E0D46 /* ProtoscopeTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		EB7841BD1B3BB114008E5160 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EB7841C41B3BB114008E5160 /* libMMMarkdown-Mac.a */,
+				EB7841C61B3BB114008E5160 /* libMMMarkdown-iOS.a */,
+				EB7841C81B3BB114008E5160 /* MMMarkdownTests.xctest */,
+				EB7841CA1B3BB114008E5160 /* mmmarkdown */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -260,6 +305,10 @@
 			productRefGroup = 962558F71B39AF1A005E4360 /* Products */;
 			projectDirPath = "";
 			projectReferences = (
+				{
+					ProductGroup = EB7841BD1B3BB114008E5160 /* Products */;
+					ProjectRef = EB7841BC1B3BB114008E5160 /* MMMarkdown.xcodeproj */;
+				},
 				{
 					ProductGroup = 96DBF35E1B3AF243003E0D46 /* Products */;
 					ProjectRef = 96DBF35D1B3AF243003E0D46 /* Prototope.xcodeproj */;
@@ -334,6 +383,34 @@
 			fileType = wrapper.cfbundle;
 			path = ProtoscopeTests.xctest;
 			remoteRef = 96DBF37D1B3AF243003E0D46 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		EB7841C41B3BB114008E5160 /* libMMMarkdown-Mac.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libMMMarkdown-Mac.a";
+			remoteRef = EB7841C31B3BB114008E5160 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		EB7841C61B3BB114008E5160 /* libMMMarkdown-iOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libMMMarkdown-iOS.a";
+			remoteRef = EB7841C51B3BB114008E5160 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		EB7841C81B3BB114008E5160 /* MMMarkdownTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = MMMarkdownTests.xctest;
+			remoteRef = EB7841C71B3BB114008E5160 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		EB7841CA1B3BB114008E5160 /* mmmarkdown */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = mmmarkdown;
+			remoteRef = EB7841C91B3BB114008E5160 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -480,6 +557,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Prototope/ThirdParty/pop/build/Debug-iphoneos",
@@ -489,11 +567,14 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/prototope/Prototope",
 					"$(SRCROOT)/prototope/ThirdParty/**",
+					"$(CONFIGURATION_BUILD_DIR)/MMMarkdown-iOS/public/",
 				);
 				INFOPLIST_FILE = "Early Math Prototype Player/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/prototope/ThirdParty/**";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Early Math Prototype Player/Early Math Prototype Player-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = 2;
 				USER_HEADER_SEARCH_PATHS = "";
 			};
@@ -504,6 +585,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Prototope/ThirdParty/pop/build/Debug-iphoneos",
@@ -513,11 +595,13 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/prototope/Prototope",
 					"$(SRCROOT)/prototope/ThirdParty/**",
+					"$(CONFIGURATION_BUILD_DIR)/MMMarkdown-iOS/public/",
 				);
 				INFOPLIST_FILE = "Early Math Prototype Player/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/prototope/ThirdParty/**";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Early Math Prototype Player/Early Math Prototype Player-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = 2;
 				USER_HEADER_SEARCH_PATHS = "";
 			};

--- a/Early Math Prototype Player.xcodeproj/project.pbxproj
+++ b/Early Math Prototype Player.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		96DBF3831B3AF25A003E0D46 /* PrototopeJSBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96DBF3741B3AF243003E0D46 /* PrototopeJSBridge.framework */; };
 		96DBF3841B3AF25A003E0D46 /* PrototopeJSBridge.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 96DBF3741B3AF243003E0D46 /* PrototopeJSBridge.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		96DBF3901B3AFE68003E0D46 /* protoscope-bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 96DBF38F1B3AFE68003E0D46 /* protoscope-bundle.js */; };
+		EB3CBCF61B3B2ADE0038AE64 /* ReadmeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3CBCF51B3B2ADE0038AE64 /* ReadmeViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -128,6 +129,7 @@
 		962559221B39AFB9005E4360 /* Early-Math-Prototypes */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Early-Math-Prototypes"; sourceTree = "<group>"; };
 		96DBF35D1B3AF243003E0D46 /* Prototope.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Prototope.xcodeproj; path = Prototope/Prototope.xcodeproj; sourceTree = SOURCE_ROOT; };
 		96DBF38F1B3AFE68003E0D46 /* protoscope-bundle.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "protoscope-bundle.js"; sourceTree = "<group>"; };
+		EB3CBCF51B3B2ADE0038AE64 /* ReadmeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadmeViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +167,7 @@
 				9625591F1B39AF96005E4360 /* Model */,
 				962558FB1B39AF1A005E4360 /* AppDelegate.swift */,
 				9625591B1B39AF72005E4360 /* PrototypeListTableViewController.swift */,
+				EB3CBCF51B3B2ADE0038AE64 /* ReadmeViewController.swift */,
 				9625591D1B39AF80005E4360 /* PlayerViewController.swift */,
 				962559021B39AF1A005E4360 /* Images.xcassets */,
 				962559041B39AF1A005E4360 /* LaunchScreen.xib */,
@@ -358,6 +361,7 @@
 				962558FC1B39AF1A005E4360 /* AppDelegate.swift in Sources */,
 				9625591E1B39AF80005E4360 /* PlayerViewController.swift in Sources */,
 				962559211B39AFA6005E4360 /* PrototypeProvider.swift in Sources */,
+				EB3CBCF61B3B2ADE0038AE64 /* ReadmeViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Early Math Prototype Player/AppDelegate.swift
+++ b/Early Math Prototype Player/AppDelegate.swift
@@ -24,9 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		
 		prototypeListTableViewController = PrototypeListTableViewController(style: .Plain)
 		
-		navigationController = UINavigationController(rootViewController: prototypeListTableViewController)
-		navigationController.navigationBarHidden = true
-		
+		navigationController = UINavigationController(rootViewController: prototypeListTableViewController)		
 
 		window?.rootViewController = navigationController
 		

--- a/Early Math Prototype Player/AppDelegate.swift
+++ b/Early Math Prototype Player/AppDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UINavigationControllerDelegate {
 
 	var window: UIWindow?
 	var prototypeListTableViewController: PrototypeListTableViewController!
@@ -24,7 +24,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		
 		prototypeListTableViewController = PrototypeListTableViewController(style: .Plain)
 		
-		navigationController = UINavigationController(rootViewController: prototypeListTableViewController)		
+		navigationController = UINavigationController(rootViewController: prototypeListTableViewController)
+		navigationController.delegate = self
 
 		window?.rootViewController = navigationController
 		
@@ -41,5 +42,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		self.navigationController.popToRootViewControllerAnimated(true)
 	}
 
+	// Hacks to show/hide navigation bar in prototypes so hack wow
+	func navigationController(navigationController: UINavigationController, willShowViewController viewController: UIViewController, animated: Bool) {
+		if viewController is PlayerViewController {
+			navigationController.setNavigationBarHidden(true, animated: true)
+		} else {
+			navigationController.setNavigationBarHidden(false, animated: true)
+		}
+	}
 }
 

--- a/Early Math Prototype Player/Early Math Prototype Player-Bridging-Header.h
+++ b/Early Math Prototype Player/Early Math Prototype Player-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <MMMarkdown/MMMarkdown.h>

--- a/Early Math Prototype Player/Info.plist
+++ b/Early Math Prototype Player/Info.plist
@@ -31,7 +31,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIStatusBarHidden~ipad</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Early Math Prototype Player/PlayerViewController.swift
+++ b/Early Math Prototype Player/PlayerViewController.swift
@@ -113,14 +113,4 @@ class PlayerViewController: UIViewController {
 		}
 	}
 
-
-	// Hacks to hide navigation bar. so prototype wow.
-	override func viewWillAppear(animated: Bool) {
-		navigationController?.setNavigationBarHidden(true, animated: true)
-	}
-
-	override func viewWillDisappear(animated: Bool) {
-		navigationController?.setNavigationBarHidden(false, animated: true)
-	}
-
 }

--- a/Early Math Prototype Player/PlayerViewController.swift
+++ b/Early Math Prototype Player/PlayerViewController.swift
@@ -113,4 +113,14 @@ class PlayerViewController: UIViewController {
 		}
 	}
 
+
+	// Hacks to hide navigation bar. so prototype wow.
+	override func viewWillAppear(animated: Bool) {
+		navigationController?.setNavigationBarHidden(true, animated: true)
+	}
+
+	override func viewWillDisappear(animated: Bool) {
+		navigationController?.setNavigationBarHidden(false, animated: true)
+	}
+
 }

--- a/Early Math Prototype Player/PrototypeListTableViewController.swift
+++ b/Early Math Prototype Player/PrototypeListTableViewController.swift
@@ -43,8 +43,12 @@ class PrototypeListTableViewController: UITableViewController {
 	override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
 		tableView.deselectRowAtIndexPath(indexPath, animated: true)
 		let prototype = self.prototypeProvider.prototypes[indexPath.row]
-		let readmeViewController = ReadmeViewController(prototype: prototype)
-		navigationController?.pushViewController(readmeViewController, animated: true)
+
+		if prototype.readmeURL != nil {
+			navigationController?.pushViewController(ReadmeViewController(prototype: prototype), animated: true)
+		} else {
+			navigationController?.pushViewController(PlayerViewController(path: prototype.mainFileURL), animated: true)
+		}
 	}
 
 

--- a/Early Math Prototype Player/PrototypeListTableViewController.swift
+++ b/Early Math Prototype Player/PrototypeListTableViewController.swift
@@ -16,7 +16,8 @@ class PrototypeListTableViewController: UITableViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.reuseIdentifier)
+		tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.reuseIdentifier)
+		navigationItem.title = "Prototypes"
 	}
 
 	
@@ -41,8 +42,9 @@ class PrototypeListTableViewController: UITableViewController {
 	
 	override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
 		tableView.deselectRowAtIndexPath(indexPath, animated: true)
-		let player = PlayerViewController(path: self.prototypeProvider.prototypes[indexPath.row].mainFileURL)
-		self.navigationController?.pushViewController(player, animated: true)
+		let prototype = self.prototypeProvider.prototypes[indexPath.row]
+		let readmeViewController = ReadmeViewController(prototype: prototype)
+		navigationController?.pushViewController(readmeViewController, animated: true)
 	}
 
 

--- a/Early Math Prototype Player/PrototypeProvider.swift
+++ b/Early Math Prototype Player/PrototypeProvider.swift
@@ -89,7 +89,7 @@ extension Prototype {
 			case 0:
 				readmeURL = nil
 			case 1:
-				readmeURL = NSURL(fileURLWithPath: readmeFiles[0])
+				readmeURL = NSURL(fileURLWithPath: path.stringByAppendingPathComponent(readmeFiles[0]))
 			default:
 				println("Multiple README files found in \(path): \(readmeFiles)")
 				return nil

--- a/Early Math Prototype Player/PrototypeProvider.swift
+++ b/Early Math Prototype Player/PrototypeProvider.swift
@@ -42,7 +42,7 @@ struct PrototypeProvider {
 /** Prototype..er, type. Represents a prototype directory on disk with reference to the main javascript file. Derived from Protorope.Prototype. */
 struct Prototype {
 	let mainFileURL: NSURL
-	let readmeURL: NSURL? = nil
+	let readmeURL: NSURL?
 	let name: String
 }
 
@@ -83,7 +83,19 @@ extension Prototype {
 				println("Multiple JavaScript files found in \(path): \(javaScriptFiles)")
 				return nil
 			}
+
+			let readmeFiles = contents!.filter { $0.lowercaseString.hasPrefix("readme.md") }
+			switch readmeFiles.count {
+			case 0:
+				readmeURL = nil
+			case 1:
+				readmeURL = NSURL(fileURLWithPath: readmeFiles[0])
+			default:
+				println("Multiple README files found in \(path): \(readmeFiles)")
+				return nil
+			}
 		} else {
+			readmeURL = nil
 			mainScriptPath = path
 		}
 		

--- a/Early Math Prototype Player/PrototypeProvider.swift
+++ b/Early Math Prototype Player/PrototypeProvider.swift
@@ -42,6 +42,7 @@ struct PrototypeProvider {
 /** Prototype..er, type. Represents a prototype directory on disk with reference to the main javascript file. Derived from Protorope.Prototype. */
 struct Prototype {
 	let mainFileURL: NSURL
+	let readmeURL: NSURL? = nil
 	let name: String
 }
 

--- a/Early Math Prototype Player/ReadmeViewController.swift
+++ b/Early Math Prototype Player/ReadmeViewController.swift
@@ -1,0 +1,54 @@
+//
+//  ReadmeViewController.swift
+//  Early Math Prototype Player
+//
+//  Created by Andy Matuschak on 6/24/15.
+//  Copyright (c) 2015 Khan Academy. All rights reserved.
+//
+
+import UIKit
+
+/** This view controller shows readmes for prototypes. */
+class ReadmeViewController: UIViewController {
+	let prototype: Prototype
+	lazy var startButton: UIButton = {
+		let button = UIButton.buttonWithType(.System) as! UIButton
+		button.setTitle("Start", forState: .Normal)
+		button.titleLabel!.font = UIFont.systemFontOfSize(24)
+		return button
+	}()
+
+	init(prototype: Prototype) {
+//		precondition(prototype.readmeURL != nil)
+		self.prototype = prototype
+		super.init(nibName: nil, bundle: nil)
+		
+		navigationItem.title = prototype.name
+	}
+
+	required init(coder aDecoder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	override func loadView() {
+		super.loadView()
+		view.backgroundColor = UIColor.whiteColor()
+
+		startButton.addTarget(self, action: "startPrototype", forControlEvents: .TouchUpInside)
+		view.addSubview(startButton)
+
+		view.setNeedsLayout()
+	}
+
+	override func viewWillLayoutSubviews() {
+		// what is the difference between a view controller and a view anyways?!?
+		startButton.sizeToFit()
+		startButton.center.x = view.bounds.size.width / 2.0
+		startButton.center.y = view.bounds.size.height - startButton.bounds.size.height / 2.0 - 50
+	}
+
+	func startPrototype() {
+		let player = PlayerViewController(path: prototype.mainFileURL)
+		navigationController!.pushViewController(player, animated: true) // what is a "control flow" anyway so lazy so prototype
+	}
+}

--- a/Early Math Prototype Player/ReadmeViewController.swift
+++ b/Early Math Prototype Player/ReadmeViewController.swift
@@ -19,8 +19,16 @@ class ReadmeViewController: UIViewController {
 	}()
 
 	init(prototype: Prototype) {
-//		precondition(prototype.readmeURL != nil)
+		precondition(prototype.readmeURL != nil)
 		self.prototype = prototype
+
+		var error: NSError?
+		let markdownSource = NSString(contentsOfURL: prototype.readmeURL!, encoding: NSUTF8StringEncoding, error: &error)
+		precondition(markdownSource != nil, "Couldn't read markdown for \(prototype.name): \(error)")
+
+		let html = MMMarkdown.HTMLStringWithMarkdown(markdownSource! as String, error: &error)
+		println(html)
+
 		super.init(nibName: nil, bundle: nil)
 		
 		navigationItem.title = prototype.name

--- a/Early Math Prototype Player/ReadmeViewController.swift
+++ b/Early Math Prototype Player/ReadmeViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 /** This view controller shows readmes for prototypes. */
 class ReadmeViewController: UIViewController {
 	let prototype: Prototype
+
 	lazy var startButton: UIButton = {
 		let button = UIButton.buttonWithType(.System) as! UIButton
 		button.setTitle("Start", forState: .Normal)
@@ -18,16 +19,16 @@ class ReadmeViewController: UIViewController {
 		return button
 	}()
 
+	lazy var webView: UIWebView = {
+		let webView = UIWebView()
+		webView.scrollView.alwaysBounceVertical = false
+		webView.backgroundColor = UIColor.clearColor()
+		return webView
+	}()
+
 	init(prototype: Prototype) {
 		precondition(prototype.readmeURL != nil)
 		self.prototype = prototype
-
-		var error: NSError?
-		let markdownSource = NSString(contentsOfURL: prototype.readmeURL!, encoding: NSUTF8StringEncoding, error: &error)
-		precondition(markdownSource != nil, "Couldn't read markdown for \(prototype.name): \(error)")
-
-		let html = MMMarkdown.HTMLStringWithMarkdown(markdownSource! as String, error: &error)
-		println(html)
 
 		super.init(nibName: nil, bundle: nil)
 		
@@ -38,12 +39,25 @@ class ReadmeViewController: UIViewController {
 		fatalError("init(coder:) has not been implemented")
 	}
 
+	private var readmeHTMLRepresentation: String {
+		var error: NSError?
+		let markdownSource = NSString(contentsOfURL: prototype.readmeURL!, encoding: NSUTF8StringEncoding, error: &error)
+		precondition(markdownSource != nil, "Couldn't read markdown for \(prototype.name): \(error)")
+
+		let body = MMMarkdown.HTMLStringWithMarkdown(markdownSource! as String, extensions: .GitHubFlavored, error: &error) ?? "Couldn't parse README: \(error)"
+		let systemFontName = UIFont.systemFontOfSize(12).fontName
+		return "<html><head><style type='text/css'>* { font-family: '\(systemFontName)' }</style><body>\(body)</body></html>"
+	}
+
 	override func loadView() {
 		super.loadView()
 		view.backgroundColor = UIColor.whiteColor()
 
 		startButton.addTarget(self, action: "startPrototype", forControlEvents: .TouchUpInside)
 		view.addSubview(startButton)
+
+		webView.loadHTMLString(readmeHTMLRepresentation, baseURL: NSURL(fileURLWithPath: "/"))
+		view.addSubview(webView)
 
 		view.setNeedsLayout()
 	}
@@ -53,9 +67,14 @@ class ReadmeViewController: UIViewController {
 		startButton.sizeToFit()
 		startButton.center.x = view.bounds.size.width / 2.0
 		startButton.center.y = view.bounds.size.height - startButton.bounds.size.height / 2.0 - 50
+
+		webView.frame.origin.y = topLayoutGuide.length + 40
+		webView.frame.size.width = 500
+		webView.frame.size.height = startButton.frame.origin.y - webView.frame.origin.y
+		webView.center.x = startButton.center.x
 	}
 
-	func startPrototype() {
+	@objc private func startPrototype() {
 		let player = PlayerViewController(path: prototype.mainFileURL)
 		navigationController!.pushViewController(player, animated: true) // what is a "control flow" anyway so lazy so prototype
 	}


### PR DESCRIPTION
We’ve got a few prototypes in here that are not really useful for someone to play with.

This change hides prototypes from the listing which have a ‘hideme’ file at their root.

I haven’t actually marked any prototypes as such yet.
